### PR TITLE
Fetch latest KMS version dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.7] - 2024-01-17
+
+### Features
+
+- Fetch the latest version of KMS CLI
+
 ## [0.1.6] - 2024-01-17
 
 ### Ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "kms_gui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "cosmian_crypto_core",
@@ -2876,6 +2876,7 @@ dependencies = [
  "cosmian_logger",
  "klask",
  "reqwest",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kms_gui"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 
@@ -13,7 +13,8 @@ klask = { git = "https://github.com/Cosmian/klask.git" }
 tokio = { version = "1.34", features = ["full"] }
 
 [build-dependencies]
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kms_gui"
 version = "0.1.7"
 edition = "2021"
+description = "Graphical interface to interact with Cosmian KMS"
 
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -37,7 +37,7 @@ fn main() {
         "async fn main_() -> Result<(), CliError> {
     let args = std::env::args().collect::<Vec<_>>();
     if args.len() < 2 {
-        let cmd = <Cli as CommandFactory>::command();
+        let cmd = <Cli as CommandFactory>::command().name(\"Cosmian KMS\");
         klask::run_app(cmd, klask::Settings::default(), |_| {});
         return Ok(())
     }\n\n",

--- a/build.rs
+++ b/build.rs
@@ -11,13 +11,16 @@ fn main() {
         .build()
         .unwrap();
 
-    let latest_kms_release = client
-        .get("https://api.github.com/repos/Cosmian/kms/releases/latest")
-        .send()
-        .unwrap()
-        .json::<Release>()
-        .unwrap()
-        .tag_name;
+    // typically the `VERSION` env var is set by the KMS CI release pipeline
+    let latest_kms_release = std::env::var("VERSION").unwrap_or_else(|_| {
+        client
+            .get("https://api.github.com/repos/Cosmian/kms/releases/latest")
+            .send()
+            .unwrap()
+            .json::<Release>()
+            .unwrap()
+            .tag_name
+    });
 
     println!("cargo:warning=Using KMS release {latest_kms_release}");
 

--- a/build.rs
+++ b/build.rs
@@ -1,24 +1,46 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+}
+
 fn main() {
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("Cosmian/KMS_GUI")
+        .build()
+        .unwrap();
+
+    let latest_kms_release = client
+        .get("https://api.github.com/repos/Cosmian/kms/releases/latest")
+        .send()
+        .unwrap()
+        .json::<Release>()
+        .unwrap()
+        .tag_name;
+
+    println!("cargo:warning=Using KMS release {latest_kms_release}");
+
     // get `ckms` `main.rs` file
-    let response = reqwest::blocking::get(
-        "https://raw.githubusercontent.com/Cosmian/kms/4.11.0/crate/cli/src/main.rs",
-    )
-    .unwrap();
-
-    let content = response.text().unwrap();
-
-    // println!("cargo:warning={content}");
+    let content = client
+        .get(format!(
+        "https://raw.githubusercontent.com/Cosmian/kms/{latest_kms_release}/crate/cli/src/main.rs"
+    ))
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
 
     // install Klask hook
     let content = content.replace(
         "async fn main_() -> Result<(), CliError> {\n",
-        "async fn main_() -> Result<(), CliError> {\n
-            let args = std::env::args().collect::<Vec<_>>();\n
-            if args.len() < 2 {\n
-                let cmd = <Cli as CommandFactory>::command();\n
-                klask::run_app(cmd, klask::Settings::default(), |_| {});\n
-                return Ok(())\n
-            }\n",
+        "async fn main_() -> Result<(), CliError> {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() < 2 {
+        let cmd = <Cli as CommandFactory>::command();
+        klask::run_app(cmd, klask::Settings::default(), |_| {});
+        return Ok(())
+    }\n\n",
     );
 
     std::fs::write("./src/main.rs", content.as_bytes()).unwrap();


### PR DESCRIPTION
The version of KMS is determined by:
- `VERSION` env var, set by the KMS CI release pipeline trigger
- fetch latest KMS version (fallback)